### PR TITLE
Removing unnecessary duplicated operations on SensorFragment

### DIFF
--- a/mobile/src/main/java/com/github/pocmo/sensordashboard/SensorFragment.java
+++ b/mobile/src/main/java/com/github/pocmo/sensordashboard/SensorFragment.java
@@ -30,6 +30,7 @@ import java.util.LinkedList;
  */
 public class SensorFragment extends Fragment {
 
+    private static final int SENSOR_TOOGLES = 6;
 
     private static final String ARG_PARAM1 = "param1";
     private long sensorId;
@@ -37,7 +38,7 @@ public class SensorFragment extends Fragment {
     private SensorGraphView sensorview;
     private float spread;
 
-    private boolean[] drawSensors = new boolean[6];
+    private boolean[] drawSensors = new boolean[SENSOR_TOOGLES];
 
     /**
      * Use this factory method to create a new instance of
@@ -92,77 +93,25 @@ public class SensorFragment extends Fragment {
         view.findViewById(R.id.legend6).setBackgroundColor(res.getColor(R.color.graph_color_6));
 
 
-// this could be better.. btu hey, it's a hackathon!
-        view.findViewById(R.id.legend1_container).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                drawSensors[0] = !drawSensors[0];
-                sensorview.setDrawSensors(drawSensors);
-                v.setSelected(drawSensors[0]);
-            }
-        });
+        String packageName = getActivity().getPackageName();
+        for(int i = 0; i < SENSOR_TOOGLES; i++){
 
-        view.findViewById(R.id.legend2_container).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                drawSensors[1] = !drawSensors[1];
-                sensorview.setDrawSensors(drawSensors);
-                v.setSelected(drawSensors[1]);
-            }
-        });
+            // Setting click listener for toggles
+            int resourceId = res.getIdentifier("legend" + (i + 1) + "_container", "id", packageName);
+            final int finalI = i;
+            view.findViewById(resourceId).setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    drawSensors[finalI] = !drawSensors[finalI];
+                    sensorview.setDrawSensors(drawSensors);
+                    v.setSelected(drawSensors[finalI]);
+                }
+            });
 
-
-        view.findViewById(R.id.legend3_container).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                drawSensors[2] = !drawSensors[2];
-                sensorview.setDrawSensors(drawSensors);
-                v.setSelected(drawSensors[2]);
-            }
-        });
-
-
-        view.findViewById(R.id.legend4_container).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                drawSensors[3] = !drawSensors[3];
-                sensorview.setDrawSensors(drawSensors);
-                v.setSelected(drawSensors[3]);
-            }
-        });
-
-
-        view.findViewById(R.id.legend5_container).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                drawSensors[4] = !drawSensors[4];
-                sensorview.setDrawSensors(drawSensors);
-                v.setSelected(drawSensors[4]);
-            }
-        });
-
-
-        view.findViewById(R.id.legend6_container).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                drawSensors[5] = !drawSensors[5];
-                sensorview.setDrawSensors(drawSensors);
-                v.setSelected(drawSensors[5]);
-            }
-        });
-
-        view.findViewById(R.id.legend1_container).setSelected(true);
-        view.findViewById(R.id.legend2_container).setSelected(true);
-        view.findViewById(R.id.legend3_container).setSelected(true);
-        view.findViewById(R.id.legend4_container).setSelected(true);
-        view.findViewById(R.id.legend5_container).setSelected(true);
-        view.findViewById(R.id.legend6_container).setSelected(true);
-
-
-        for (int i = 0; i < drawSensors.length; ++i) {
+            // Setting toggles as selected
+            view.findViewById(resourceId).setSelected(true);
             drawSensors[i] = true;
         }
-
 
         sensorview.setDrawSensors(drawSensors);
 


### PR DESCRIPTION
I've merged identical operations on SensorFragment into a single loop.
Resource ids are dynamically retrieved using function `getIdentifier`
